### PR TITLE
docs(profile): refresh org README to reflect current repo state

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -4,11 +4,12 @@ TruthDB is a collection of open source components for building and operating Tru
 
 ### Repositories
 
-- `truthdb`: Linux service providing database / streaming / event sourcing functionality
+- `truthdb`: Linux database service with io_uring-backed storage and a custom binary protocol on TCP/9623
+- `apt`: signed apt repository for TruthDB Debian packages
 - `docs`: historical and supporting documentation
-- `installer`: installer UI/application
+- `installer`: bare-metal installer (runs in the initramfs) that lays down Debian + TruthDB on a fresh machine
 - `installer-iso`: ISO build scripts/assets
-- `installer-kernel`: kernel config/initramfs for the installer
+- `installer-kernel`: custom Linux kernel config for the installer ISO
 - `installer-kernel-builder-image`: container image for building the installer kernel
 - `orchestrator`: developer/admin CLI for operating TruthDB (including releases)
 - `website`: public website


### PR DESCRIPTION
  * `truthdb`: drop the aspirational "streaming / event sourcing" framing (which lives in the capability catalogue, not in the binary) in favour of what the service actually is today — io_uring-backed storage with a custom binary protocol on TCP/9623.
  * `apt`: add the newly-live signed apt repo (https://truthdb.github.io/apt/).
  * `installer`: it's a console binary running inside the initramfs, not a "UI/application".
  * `installer-kernel`: this repo produces only the kernel; the initramfs comes from installer-iso.

No structural or intro-sentence changes.

## Summary

Describe what this PR changes and why.

## Checklist

- [ ] I kept the change focused and scoped
- [ ] I ran relevant tests/lints locally (or explained why not)
- [ ] I updated documentation where needed
- [ ] I considered backwards compatibility and migration impact

## Testing

Describe what you tested and how.
